### PR TITLE
Change dist directory for testing to temporary

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,6 +6,8 @@ from click.testing import CliRunner
 from umakaparser.services import build
 from os import path, getenv
 import i18n
+import tempfile
+import shutil
 
 LOCALE = getenv('LANG').split('_')[0]
 FILE_DIR = path.dirname(path.abspath(__file__))
@@ -28,10 +30,11 @@ def message():
 def test_validate_metadata(runner, message):
     TARGET = 'metadata'
     ASSETS_DIR = path.join(TESTDATA_DIR, TARGET, 'assets')
+    DIST_DIR = tempfile.mkdtemp(dir=path.join(TESTDATA_DIR, TARGET))
 
     def make_path(filename):
         testdata = path.join(TESTDATA_DIR, TARGET, '{}.ttl'.format(filename))
-        dist = path.join(TESTDATA_DIR, TARGET, 'dist', '{}.json'.format(filename))
+        dist = path.join(DIST_DIR, '{}.json'.format(filename))
         return testdata, dist
 
     def check_success():
@@ -111,14 +114,17 @@ def test_validate_metadata(runner, message):
     check_triples()
     check_errors()
 
+    shutil.rmtree(DIST_DIR)
+
 
 def test_validate_class_partition(runner, message):
     TARGET = 'class_partition'
     ASSETS_DIR = path.join(TESTDATA_DIR, TARGET, 'assets')
+    DIST_DIR = tempfile.mkdtemp(dir=path.join(TESTDATA_DIR, TARGET))
 
     def make_path(filename):
         testdata = path.join(TESTDATA_DIR, TARGET, '{}.ttl'.format(filename))
-        dist = path.join(TESTDATA_DIR, TARGET, 'dist', '{}.json'.format(filename))
+        dist = path.join(DIST_DIR, '{}.json'.format(filename))
         return testdata, dist
 
     def check_success():
@@ -164,14 +170,17 @@ def test_validate_class_partition(runner, message):
     check_entities()
     check_warns()
 
+    shutil.rmtree(DIST_DIR)
+
 
 def test_validate_property_partition(runner, message):
     TARGET = 'property_partition'
     ASSETS_DIR = path.join(TESTDATA_DIR, TARGET, 'assets')
+    DIST_DIR = tempfile.mkdtemp(dir=path.join(TESTDATA_DIR, TARGET))
 
     def make_path(filename):
         testdata = path.join(TESTDATA_DIR, TARGET, '{}.ttl'.format(filename))
-        dist = path.join(TESTDATA_DIR, TARGET, 'dist', '{}.json'.format(filename))
+        dist = path.join(DIST_DIR, '{}.json'.format(filename))
         return testdata, dist
 
     def check_success():
@@ -216,3 +225,5 @@ def test_validate_property_partition(runner, message):
     check_property()
     check_triples()
     check_warns()
+
+    shutil.rmtree(DIST_DIR)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -47,54 +47,54 @@ def test_validate_metadata(runner, message):
     def check_endpoint():
         TESTDATA, DIST = make_path('error_endpoint')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         assert message('Cause', 'metadata', 'endpoint') in result.output
         assert not path.exists(DIST)
 
     def check_crawl_log():
         TESTDATA, DIST = make_path('error_crawl_log')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         assert message('Cause', 'metadata', 'crawlLog') in result.output
         assert not path.exists(DIST)
 
     def check_crawl_start_time():
         TESTDATA, DIST = make_path('error_crawl_start_time')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         assert message('Cause', 'metadata', 'crawlStartTime') in result.output
         assert not path.exists(DIST)
 
     def check_default_dataset():
         TESTDATA, DIST = make_path('error_default_dataset')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         assert message('Cause', 'metadata', 'defaultDataset') in result.output
         assert not path.exists(DIST)
 
     def check_triples():
         TESTDATA, DIST = make_path('error_triples')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         assert message('Cause', 'metadata', 'triples') in result.output
         assert not path.exists(DIST)
 
     def check_errors():
         TESTDATA, DIST = make_path('errors')
         result = runner.invoke(build, [TESTDATA, '--assets', ASSETS_DIR, '--dist', DIST])
-        assert result.exit_code == 2
+        assert result.exit_code == 0
         assert '>> ' + DIST not in result.output
-        assert 'Error: Validation failed.' in result.output
+        assert 'Validation failed.' in result.output
         messages = [
             message('Cause', 'metadata', 'endpoint'),
             message('Cause', 'metadata', 'crawlStartTime'),
@@ -161,7 +161,7 @@ def test_validate_class_partition(runner, message):
         ]
         for m in messages:
             assert m in result.output
-        error_message = 'Error: '
+        error_message = 'Validation failed.'
         assert error_message not in result.output
         assert path.exists(DIST)
 
@@ -217,7 +217,7 @@ def test_validate_property_partition(runner, message):
         ]
         for m in messages:
             assert m in result.output
-        error_message = 'Error: '
+        error_message = 'Validation failed.'
         assert error_message not in result.output
         assert path.exists(DIST)
 

--- a/umakaparser/scripts/services/utils.py
+++ b/umakaparser/scripts/services/utils.py
@@ -37,8 +37,12 @@ def get_type(file_path):
         return 'n3'
 
 
+def auto_encode(msg):
+    return msg.encode('utf-8') if six.PY2 else msg
+
+
 def i18n_t(key, **kwargs):
-    return i18n.t(key, **kwargs).encode('utf-8') if six.PY2 else i18n.t(key, **kwargs)
+    return auto_encode(i18n.t(key, **kwargs))
 
 
 def timer(fn):

--- a/umakaparser/scripts/services/validate.py
+++ b/umakaparser/scripts/services/validate.py
@@ -3,8 +3,7 @@
 
 from rdflib import URIRef
 import i18n
-from click import UsageError
-import six
+from .utils import auto_encode
 
 
 def create_triple(s=None, p=None, o=None):
@@ -103,6 +102,7 @@ def validate_property_partition(graph):
 class GraphValidationError(Exception):
     pass
 
+
 def validate_graph(graph):
 
     errors = []
@@ -110,7 +110,7 @@ def validate_graph(graph):
 
     if 0 < len(errors):
         message = 'Validation failed.\n' + '\n'.join(['Cause: ' + e for e in errors])
-        raise GraphValidationError(message)
+        raise GraphValidationError(auto_encode(message))
 
     warns = []
     warns.extend([error_message('ClassPartition', t) for t in validate_class_partition(graph)])
@@ -118,4 +118,4 @@ def validate_graph(graph):
 
     if 0 < len(warns):
         message = '\n'.join(['Warn: ' + w for w in warns])
-        print(message.encode('utf-8') if six.PY2 else message)
+        print(auto_encode(message))


### PR DESCRIPTION
348b1a0
テスト時の出力ファイルを一時ディレクトリを出力するように修正
※ tempfile.TemporaryDirectoryはPython3.2以降にしかないので、mkdtempを使用しました。

f431d6b
標準出力周りの変更に合わせて、テストを修正
また、Python2.7でGraphValidatioonErrorが発生した際にUnicodeDecodeErrorが起こる問題の修正