### PR TITLE
fix assets format

### DIFF
--- a/umakaparser/scripts/services/assets.py
+++ b/umakaparser/scripts/services/assets.py
@@ -11,6 +11,7 @@ from itertools import chain
 from .utils import IGNORE_CLASSES, i18n_t
 import resource
 from tqdm import tqdm
+import json
 
 
 # 複数のturtleファイルを5万tripleを1つのチャンクとして
@@ -89,7 +90,8 @@ def output_process(args):
                 _, file_path = tempfile.mkstemp(dir=os.path.join(base_dir, output))
                 output_fp[output] = open(file_path, 'w')
             fp = output_fp[output]
-            fp.write('{} {}\n'.format(s.n3(), o.n3()))
+            fp.write(json.dumps({'s': s.n3(), 'o': o.n3()}))
+            fp.write('\n')
     for fp in output_fp.values():
         fp.close()
 

--- a/umakaparser/scripts/services/build.py
+++ b/umakaparser/scripts/services/build.py
@@ -192,7 +192,9 @@ class AssetReader(object):
             with open(os.path.join(self.assets_dir, filename)) as fp:
                 for row in fp:
                     row = row.strip()
-                    yield tuple(map(lambda x: URIRef(x[1:-1]).n3(graph.namespace_manager).strip('<>'), row.split(' ', 1)))
+                    obj = json.loads(row)
+                    so = obj['s'], obj['o']
+                    yield tuple(map(lambda x: URIRef(x[1:-1]).n3(graph.namespace_manager).strip('<>'), so))
         except IOError:
             return
 
@@ -202,8 +204,8 @@ class AssetReader(object):
         try:
             with open(os.path.join(self.assets_dir, filename)) as fp:
                 for row in fp:
-                    row = row.strip()
-                    s, o = row.split(' ', 1)
+                    obj = json.loads(row)
+                    s, o = obj['s'], obj['o']
                     yield URIRef(s[1:-1]).n3(graph.namespace_manager).strip('<>'), parse_literal(o)
         except IOError:
             return


### PR DESCRIPTION
```
###  http://purl.jp/bio/12/glyco/glycan#Glycoprotein
:Glycoprotein rdf:type owl:Class ;
              owl:equivalentClass :glycoprotein ;
              rdfs:subClassOf :glycoconjugate ;
              rdfs:label "Glycoprotein"@en ,
                         """Initial class name is capitalized.
\"glycan:Glycoprotein"""@en .
```
こういう改行が含まれるような目的語のための修正