### PR TITLE
ラベル情報追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 .ropeproject
 .DS_Store
 .vscode
+
+# assets folder
+assets/

--- a/umakaparser/scripts/services/build.py
+++ b/umakaparser/scripts/services/build.py
@@ -30,7 +30,7 @@ class ClassResource(object):
         self.subClassOf = None
 
     def serialize(self):
-        result = {'label': labels_lang(self.label)}
+        result = {}
         if self.subClassOf:
             result['subClassOf'] = self.subClassOf
         return result
@@ -312,10 +312,6 @@ def class_reference(graph, classes, structure, classes_map, sub_class_map, asset
 
     for top in structure:
         flat_structure(top)
-
-    for s, o in asset_reader.read_subject_literal('label', graph):
-        if s in classes_map:
-            classes_map[s].label.append(o)
 
     for s, o in classes_map.items():
         if s in sub_class_map:


### PR DESCRIPTION
### 目的
述語などに`rdfs:label`が設定されている場合優先的に表示させたい、という修正内容

### やったこと
- `umakaparser build`を行った際assetsフォルダが指定されている場合、すべてのuriの`rdfs:label`を取ってこれるように修正
- classesからlabel情報を削除

### 例
```
{
  "inheritance_structure": [
    ...
  ],
  "classes": {
    ...
  },
  "properties": [
    ...
  ],
  "prefixes": {
    ...
  },
  "meta_data": {
    ...
  },
  "labels": { // NEW
    "sio:SIO_001247": {
      "en": "is transitively related to"
    },
    "sio:SIO_000998": {
      "en": "literature curation"
    },
    ...
  }
}

```
